### PR TITLE
Fix CORS config

### DIFF
--- a/server.js
+++ b/server.js
@@ -6,7 +6,11 @@ const cors = require('cors');
 const app = express();
 const port = 3001;
 
-app.use(cors());
+const allowedOrigins = process.env.ALLOWED_ORIGINS
+  ? process.env.ALLOWED_ORIGINS.split(',')
+  : ['http://localhost:3000'];
+
+app.use(cors({ origin: allowedOrigins }));
 app.use(express.json());
 
 const openai = new OpenAI({


### PR DESCRIPTION
## Summary
- restrict CORS origins in `server.js`

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_684920a664d083339b90339bfd8ee018