### PR TITLE
Add language and tone settings

### DIFF
--- a/server.js
+++ b/server.js
@@ -19,15 +19,16 @@ const openai = new OpenAI({
 
 app.post('/api/chat', async (req, res) => {
   try {
-    const { messages, role } = req.body; // Destructure role from the request body
+    const { messages, role, language, tone } = req.body; // Destructure additional fields
 
     if (!messages) {
       return res.status(400).json({ error: 'Messages are required' });
     }
 
-    // --- NEW: Dynamic System Prompt based on role ---
+    // --- NEW: Dynamic System Prompt based on role, tone and language ---
     const systemPrompt = `You are Care Mate, a professional, supportive, and rights-based AI assistant for the Australian NDIS.
     You are currently assisting a user with the role of: ${role || 'Participant'}. You MUST tailor your tone, guidance, and language for this specific role. For Participants, use simpler language and an encouraging tone. For Support Coordinators and Plan Managers, use more professional and technical language.
+    Respond in ${language || 'English (Australia)'} using a ${tone || 'Standard'} tone.
     Your job is to: Explain NDIS plans, generate structured documentation, suggest goals and services, and translate complex terms into plain language.
     Always respect participant rights, choice, and control. Never give medical advice. If you are unsure about something, say so and suggest how the user can find official clarification. Default to empathy and helpfulness.`;
     

--- a/src/app/chat/page.js
+++ b/src/app/chat/page.js
@@ -1,6 +1,8 @@
 'use client';
 
 import React, { useState, useEffect, useRef } from 'react';
+import SettingsModal from '@/components/SettingsModal';
+import { useChatSettings } from '@/context/ChatSettingsContext';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import TextareaAutosize from 'react-textarea-autosize';
@@ -25,6 +27,7 @@ const PromptBubble = ({ title, subtitle, onClick }) => ( <button onClick={onClic
 
 export default function ChatPage() {
   const searchParams = useSearchParams();
+  const { language, tone } = useChatSettings();
   const role = searchParams.get('role') || 'Participant';
   const goal = searchParams.get('goal') || 'Draft a progress letter';
   const prompt = searchParams.get('prompt');
@@ -34,6 +37,7 @@ export default function ChatPage() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
   const chatContainerRef = useRef(null);
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
 
   useEffect(() => {
     if (prompt) {
@@ -63,7 +67,7 @@ export default function ChatPage() {
       const response = await fetch(`${apiUrl}/api/chat`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ messages: newMessages, role })
+        body: JSON.stringify({ messages: newMessages, role, language, tone })
       });
 
       if (!response.ok) {
@@ -125,6 +129,8 @@ export default function ChatPage() {
   const handlePromptClick = (text) => { setInputValue(text); };
 
   return (
+    <>
+    <SettingsModal isOpen={isSettingsOpen} onClose={() => setIsSettingsOpen(false)} />
     <div className="flex h-screen bg-background text-primary-text font-sans">
       <aside className="w-80 bg-[#111111] p-4 flex flex-col border-r border-white/10">
         <button className="flex items-center justify-center gap-2 w-full p-3 rounded-full bg-primary-text text-background font-semibold hover:bg-white/80 transition mb-6">
@@ -142,7 +148,7 @@ export default function ChatPage() {
             <nav className="flex flex-col space-y-1"> {commonRequests.map(request => ( <button key={request.title} onClick={() => handlePromptClick(request.template)} className="p-2 text-sm text-left truncate rounded-lg text-secondary-text hover:bg-white/5 hover:text-primary-text transition-colors">{request.title}</button>))} </nav>
         </div>
         <div className="pt-4 border-t border-white/10">
-            <button className="w-full flex items-center gap-2 p-2 text-sm rounded-lg text-secondary-text hover:bg-white/5 hover:text-primary-text transition-colors"> <SettingsIcon /> Settings </button>
+            <button onClick={() => setIsSettingsOpen(true)} className="w-full flex items-center gap-2 p-2 text-sm rounded-lg text-secondary-text hover:bg-white/5 hover:text-primary-text transition-colors"> <SettingsIcon /> Settings </button>
         </div>
       </aside>
 
@@ -192,5 +198,6 @@ export default function ChatPage() {
         </div>
       </main>
     </div>
+    </>
   );
 }

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -2,6 +2,7 @@ import { Inter } from 'next/font/google';
 import './globals.css';
 import Header from '@/components/Header';
 import SmoothScroll from '@/components/SmoothScroll';
+import { ChatSettingsProvider } from '@/context/ChatSettingsContext';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -14,8 +15,10 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en">
       <body className={inter.className}>
-        <Header />
-        <SmoothScroll>{children}</SmoothScroll>
+        <ChatSettingsProvider>
+          <Header />
+          <SmoothScroll>{children}</SmoothScroll>
+        </ChatSettingsProvider>
       </body>
     </html>
   );

--- a/src/components/SettingsModal.js
+++ b/src/components/SettingsModal.js
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import { useChatSettings } from '@/context/ChatSettingsContext';
 import { motion, AnimatePresence } from 'framer-motion';
 
 // --- ICONS ---
@@ -11,7 +12,10 @@ const ProfileIcon = () => <svg className="h-5 w-5" fill="none" viewBox="0 0 24 2
 
 
 const SettingsModal = ({ isOpen, onClose }) => {
+  const { language: globalLanguage, setLanguage: setGlobalLanguage, tone: globalTone, setTone: setGlobalTone } = useChatSettings();
   const [activeTab, setActiveTab] = useState('profile');
+  const [language, setLanguage] = useState(globalLanguage);
+  const [tone, setTone] = useState(globalTone);
 
   // This check is important to allow the exit animation to complete
   if (!isOpen) {
@@ -84,15 +88,35 @@ const SettingsModal = ({ isOpen, onClose }) => {
                          <div>
                            <label className="font-semibold text-primary-text">Language Output</label>
                            <p className="text-xs text-secondary-text mb-2">Choose the primary language for AI responses.</p>
-                           <select className="mt-1 bg-[#1A1A1A] border border-white/10 rounded-lg p-3 w-full focus:outline-none focus:ring-2 focus:ring-primary"><option>English (Australia)</option></select>
+                           <select
+                             value={language}
+                             onChange={(e) => {
+                               setLanguage(e.target.value);
+                               setGlobalLanguage(e.target.value);
+                             }}
+                             className="mt-1 bg-[#1A1A1A] border border-white/10 rounded-lg p-3 w-full focus:outline-none focus:ring-2 focus:ring-primary"
+                           >
+                             <option>English (Australia)</option>
+                             <option>Spanish</option>
+                             <option>French</option>
+                           </select>
                          </div>
                          <div>
                            <label className="font-semibold text-primary-text">AI Response Tone</label>
                            <p className="text-xs text-secondary-text mb-2">Select the tone that best suits your needs.</p>
                            <div className="flex gap-2 mt-2">
-                             <button className="flex-1 p-2 rounded-lg bg-primary text-background font-semibold">Simple</button>
-                             <button className="flex-1 p-2 rounded-lg bg-[#1A1A1A] text-secondary-text hover:border-primary border border-transparent transition-colors">Standard</button>
-                             <button className="flex-1 p-2 rounded-lg bg-[#1A1A1A] text-secondary-text hover:border-primary border border-transparent transition-colors">Professional</button>
+                             {['Simple', 'Standard', 'Professional'].map(t => (
+                               <button
+                                 key={t}
+                                 onClick={() => {
+                                   setTone(t);
+                                   setGlobalTone(t);
+                                 }}
+                                 className={`flex-1 p-2 rounded-lg border transition-colors ${tone === t ? 'bg-primary text-background font-semibold' : 'bg-[#1A1A1A] text-secondary-text hover:border-primary border-transparent'}`}
+                               >
+                                 {t}
+                               </button>
+                             ))}
                            </div>
                          </div>
                        </div>

--- a/src/context/ChatSettingsContext.js
+++ b/src/context/ChatSettingsContext.js
@@ -1,0 +1,16 @@
+import React, { createContext, useContext, useState } from 'react';
+
+const ChatSettingsContext = createContext();
+
+export const ChatSettingsProvider = ({ children }) => {
+  const [language, setLanguage] = useState('English (Australia)');
+  const [tone, setTone] = useState('Simple');
+
+  return (
+    <ChatSettingsContext.Provider value={{ language, setLanguage, tone, setTone }}>
+      {children}
+    </ChatSettingsContext.Provider>
+  );
+};
+
+export const useChatSettings = () => useContext(ChatSettingsContext);


### PR DESCRIPTION
## Summary
- add chat settings context to store language and tone
- wrap layout with provider
- allow setting language and tone in SettingsModal
- send selected settings with chat messages
- update server prompt with chosen language and tone

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684927767b0883338b9021d5c79bccce