### PR TITLE
Make server port configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 OPENAI_API_KEY=your-openai-key-here
 NEXT_PUBLIC_API_URL=http://localhost:3001
+# Port for the Express server (default 3001)
+PORT=3001

--- a/README.md
+++ b/README.md
@@ -15,10 +15,14 @@ This project is a Next.js application.
 2. Edit `.env` and provide values for the following variables:
    - `OPENAI_API_KEY` – your OpenAI API key.
    - `ALLOWED_ORIGINS` – comma-separated list of URLs allowed to access the backend.
+   - `PORT` – port for the Express server (defaults to `3001`).
 
 ## Running the Backend
 
-- `node server.js` – start the Express server directly.
+The Express server reads the `PORT` environment variable. If not set, it
+defaults to `3001`.
+
+- `node server.js` – start the server directly.
 - `npm run server` – start it via the provided npm script.
 
 ## Running Tests

--- a/server.js
+++ b/server.js
@@ -4,7 +4,8 @@ const OpenAI = require('openai');
 const cors = require('cors');
 
 const app = express();
-const port = 3001;
+// Allow overriding the server port via environment variable
+const port = process.env.PORT || 3001;
 
 const allowedOrigins = process.env.ALLOWED_ORIGINS
   ? process.env.ALLOWED_ORIGINS.split(',')


### PR DESCRIPTION
## Summary
- allow setting `PORT` for Express server
- document `PORT` in example env file
- mention `PORT` usage in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849277936c0833380c0840692f64860